### PR TITLE
Add Github action for uploading arduino-esp32 component.

### DIFF
--- a/.github/workflows/upload-idf-component.yml
+++ b/.github/workflows/upload-idf-component.yml
@@ -1,9 +1,8 @@
 name: Push components to https://components.espressif.com
 on:
   push:
-    # TODO
-    # branches:
-    #   - main
+     branches:
+       - master
 jobs:
   upload_components:
     runs-on: ubuntu-latest
@@ -18,5 +17,4 @@ jobs:
           name: arduino-esp32
           namespace: espressif
           api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}
-          # TODO: use production one
-          service_url: https://api.staging.components.espressif.tools/
+          service_url: ${{ secrets.IDF_COMPONENT_API_URL }}

--- a/.github/workflows/upload-idf-component.yml
+++ b/.github/workflows/upload-idf-component.yml
@@ -1,0 +1,22 @@
+name: Push components to https://components.espressif.com
+on:
+  push:
+    # TODO
+    # branches:
+    #   - main
+jobs:
+  upload_components:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          submodules: "recursive"
+
+      - name: Upload components to the component registry
+        uses: espressif/github-actions/upload_components@master
+        with:
+          name: arduino-esp32
+          namespace: espressif
+          api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}
+          # TODO: use production one
+          service_url: https://api.staging.components.espressif.tools/

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,4 @@
+# TODO: Use git version
+version: "0.0.1"
+description: "Arduino Wiring-based Framework for the Espressif ESP32, ESP32-S and ESP32-C series of SoCs"
+url: "https://github.com/espressif/arduino-esp32"


### PR DESCRIPTION
## Summary
Add upload-idf-componen.yml file for Github Workflow. After each push on the master branch, the component will be uploaded to the component registry

## Impact
After that PR users can use the Arduino-ESP32 component from the component registry.